### PR TITLE
Enable log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ Once your database and user have been created, and the user has the correct perm
     >>> import api
     >>> api.core.Base.metadata.create_all(api.engine)  # creates tables from sqlalchemy models inherited from api root
 
+### Configuring Logfiles
+
+If you would like to persist the application's logs to a file, you are able to configure a rotating file handler.  You can do so by adding the following options to `settings.cfg`, replacing the values with whatever is suitable to you:
+    
+    [logging]
+    file_name = /var/log/TheBestBookOn/output.log
+    log_level = DEBUG
+    max_bytes = 268435456
+    backup_count = 2
+
+Of the above options, `file_name` is the only one that is required.  Default values will be used for the other options if they are not present.
+
 ## Run server
 
     $ python app.py

--- a/bestbook/app.py
+++ b/bestbook/app.py
@@ -12,8 +12,9 @@
 from flask import Flask
 from flask_routing import router
 from flask_cors import CORS
+from logging.config import dictConfig
 import views
-from configs import options, SECRET_KEY
+from configs import options, SECRET_KEY, LOGGER
 
 urls = ('/admin', views.Admin,
         '/people/<username>', views.User,
@@ -29,6 +30,8 @@ urls = ('/admin', views.Admin,
 app = router(Flask(__name__), urls)
 app.secret_key = SECRET_KEY
 cors = CORS(app)
+
+dictConfig(LOGGER)
 
 if __name__ == "__main__":
     app.run(**options)

--- a/bestbook/configs/__init__.py
+++ b/bestbook/configs/__init__.py
@@ -51,3 +51,27 @@ DB_URI = '%(dbn)s://%(user)s:%(pw)s@%(host)s:%(port)s/%(db)s' % {
     'db': config.getdef('db', 'db', 'bestbooks'),
     'pw': config.getdef('db', 'pw', '')
     }
+
+# Default logging configuration:
+LOGGER = {
+    'version': 1,
+    'handlers': {'wsgi': {
+        'class': 'logging.StreamHandler',
+        'stream': 'ext://flask.logging.wsgi_errors_stream',
+    }},
+    'root': {
+        'level': config.getdef('logging', 'log_level', 'INFO'),
+        'handlers': ['wsgi']
+    }
+}
+
+# Log file configuration:
+if config.has_section('logging') and config.has_option('logging', 'file_name'):
+    LOGGER['handlers'].update(
+        {'file': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': config.get('logging', 'file_name'),
+            'maxBytes': int(config.getdef('logging', 'max_bytes', '268435456')),
+            'backupCount': int(config.getdef('logging', 'backup_count', '2'))
+        }})
+    LOGGER['root']['handlers'].append('file')


### PR DESCRIPTION
Closes #31 

Allows rotating log files to be configured in `settings.cfg`.  Existing console logging remains as-is.

README has also been updated with configuration details.