### PR TITLE
Improve CORS

### DIFF
--- a/bestbook/app.py
+++ b/bestbook/app.py
@@ -23,7 +23,6 @@ urls = ('/admin', views.Admin,
         '/people/<username>', views.User,
         '/logout', views.Logout,
         '/api/', views.Index,
-        '/api/observations', views.Observations,
         '/api/<cls>/<_id>', views.Router,
         '/api/<cls>', views.Router,
         '/<path:resource>', views.Section,
@@ -32,7 +31,10 @@ urls = ('/admin', views.Admin,
 
 app = router(Flask(__name__), urls)
 app.secret_key = SECRET_KEY
-cors = CORS(app)
+cors = CORS(app, resources={
+    r"/api/*": {"methods": ["GET"], "origins": "*"},
+    r"/api/observations": {"methods": ["POST"], "origins": r"https://((dev|staging)\.)?openlibrary\.org"}
+})
 
 app.jinja_env.globals.update(fetch_work=fetch_work)
 dictConfig(LOGGER)


### PR DESCRIPTION
Closes #29 

This PR will allow cross origin GET requests to all `/api/*` endpoints, with the exception of `/api/observations` (more on this below).  It also allows POSTs to `/api/observations` from staging, dev, and production instances of Open Library.  Most importantly, it prevents requests and recommendations from being deleted from outside of the application.

CORS configurations were made globally in `app.py`.  Configuring the POST rules for `/api/observations` overrode the GET rule.  I think that this can be remedied by setting allowed methods with the `@app.routes` decorator, but this will take some refactoring to implement (the Router class should be moved to its own file to avoid circular imports and its functions maybe shouldn't handle all endpoints in a generic fashion).

Speaking of the Router class, I had to move the POST `/api/observations` functionality from Observations to Router in order for CORS to work properly.  I don't really understand why this is the case, and I find it a bit maddening...

I'm also noticing the preflight OPTIONS responses are returning more allowed methods that are actually allowed.

All of this is to say that this works, but could be improved.