### PR TITLE
Correct favicon URL

### DIFF
--- a/bestbook/templates/base.html
+++ b/bestbook/templates/base.html
@@ -8,7 +8,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="/static/build/css/style.css"/>
-        <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+        <link rel="shortcut icon" href="{{ url_for('static', filename='imgs/favicon.ico') }}">
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0-alpha1/jquery.min.js"></script>
         <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
         <script src="/static/build/js/index.js"></script>


### PR DESCRIPTION
favicon location corrected in `base.html`.  Requests for favicons no longer return 404, and TBBO tabs are more delightful.

![tab](https://user-images.githubusercontent.com/28732543/103586534-46456e80-4eb3-11eb-836e-8145f421d5f4.png)
