### PR TITLE
adds single /recommendation/:id page

### DIFF
--- a/bestbook/app.py
+++ b/bestbook/app.py
@@ -26,6 +26,8 @@ urls = ('/admin', views.Admin,
         '/api/observations', views.Observations,
         '/api/<cls>/<_id>', views.Router,
         '/api/<cls>', views.Router,
+        '/recommendations/<slug>/<rid>', views.RecommendationPage,
+        '/recommendations/<rid>', views.RecommendationPage,
         '/<path:resource>', views.Section,
         '/', views.Base
         )

--- a/bestbook/templates/recommendation.html
+++ b/bestbook/templates/recommendation.html
@@ -1,0 +1,18 @@
+<h2>The best book on: "{{ rec.topic.name }}" by {{ rec.username }}:</h2>
+
+<div class="block">
+  <div class="recommendation">
+    <div><a href="https://openlibrary.org/{{rec.winner.work_olid}}"><img src="https://covers.openlibrary.org/b/olid/{{rec.winner.work_olid.split('/')[-1]}}-M.jpg"></a></div>
+    <div>
+      <p>{{ rec.description }}</p>
+      <ul>
+	{% for candidate in rec.candidates %}
+        <p>{{ candidate }}</p>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+
+
+

--- a/bestbook/views/__init__.py
+++ b/bestbook/views/__init__.py
@@ -49,7 +49,7 @@ def require_admin(f):
             return f(*args, **kwargs)
         return "Administrators Only", 401
     return inner
-    
+
 def rest(f):
     def inner(*args, **kwargs):
         try:
@@ -313,6 +313,14 @@ class RecommendationApproval(MethodView):
             "books": Book,
             "topics": Topic
         })
+
+class RecommendationPage(MethodView):
+    def get(self, rid=None, slug=""):
+        try:
+            rec = Recommendation.get(int(rid))
+        except RexException as e:
+            return redirect(request.url_root)
+        return render_template("base.html", template="recommendation.html", rec=rec)
 
 class RequestApproval(MethodView):
     def get(self):


### PR DESCRIPTION
Adds a minimal, unstyled endpoint which allows patrons to view and share a link for a specific recommendation.

The endpoint begins with `/recommendations` and terminates with a numeric identified -- e.g. `/recommendations/1`. In between the identifier and the page-type can be an optional human readable [slug](https://en.wikipedia.org/wiki/Clean_URL#Slug for SEO and readability purposes) whose actual value is more or less ignored.

```
    '/recommendations/<slug>/<rid>', views.RecommendationPage,
    '/recommendations/<rid>', views.RecommendationPage,
```