### PR TITLE
GitHub Actions: Add mypy for Python type checking

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,10 +6,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install black codespell flake8 isort pytest
+      - run: pip install black codespell flake8 isort mypy pytest
       - run: black --check . || true
       - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
       - run: pip install -r requirements.txt
+      - run: mypy --ignore-missing-imports . || true
       - run: pytest . || true


### PR DESCRIPTION
Add [Mypy: Optional Static Typing for Python](https://github.com/python/mypy) running in _allow failures_ mode in our GitHub Actions until we get our code into compliance.  https://docs.python.org/3/library/typing.html

@aasifkhan7 @jamesachamp It seems like we are close to mypy compatibility but it gets confused because we did not make a proper subclass of ConfigParser and because `models` and `PRIVATE_ENDPOINTS` have no type hints.

__mypy --ignore-missing-imports .__
```
bestbook/configs/__init__.py:19: error: Name 'ConfigParser' already defined (possibly by an import)
bestbook/configs/__init__.py:33: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:35: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:36: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:37: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:42: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:44: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:48: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:49: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:50: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:51: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:52: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:53: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:64: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:71: error: "object" has no attribute "update"
bestbook/configs/__init__.py:75: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:76: error: "ConfigParser" has no attribute "getdef"
bestbook/configs/__init__.py:78: error: Value of type "object" is not indexable
bestbook/api/core.py:21: error: Need type annotation for 'models' (hint: "models: Dict[<type>, <type>] = ...")
bestbook/views/__init__.py:35: error: Need type annotation for 'PRIVATE_ENDPOINTS' (hint: "PRIVATE_ENDPOINTS: List[<type>] = ...")
Found 20 errors in 3 files (checked 9 source files)
```