### PR TITLE
restrict POST with authentication

### DIFF
--- a/bestbook/api/auth.py
+++ b/bestbook/api/auth.py
@@ -14,30 +14,54 @@ def is_admin(username):
     return '/people/%s' % username in admins
 
 
-def login(email, password):
-    """Authenticates user and returns session"""
+def authenticate(email=None, password=None, s3_keys=None, expected_username=None):
+    """
+    :parm dict s3_keys: a dict {'secret': 'xxx', 'access': 'yyy'}
+    :param str expected_username: expected username for account w/ s3_keys
+    """
+    username = None
 
-    email = email.replace(' ', '+')
-
-    # We're already logged in, so return a True value
-    if session.get('username'):
-        return session.get('username')
-
+    # We're logged in and thus authenticated
     try:
-        response = get_auth_config(email, password)
+        if session.get('username'):
+            username = session.get('username')
+    except RuntimeError:
+        # If we don't have web request ctx, skip to keys
+        pass
 
+    if not username and (email and password):
+        email = email.replace(' ', '+')
+        # May raise AuthenticationError
+        response = get_auth_config(email, password)
+        s3_keys = response.get('s3')
+
+    if not username and s3_keys:
         # We now know the user's credentials are correct.
         # Next, we need to get their OpenLibrary username
         headers = {'Content-Type': 'application/json'}
         r = requests.post(
             '%s/account/login' % ol_url,
             headers=headers,
-            json=response.get('s3')
+            json=s3_keys
         )
         username = r.cookies.get('session').split('/')[2].split('%2C')[0]
-        session['username'] = username
-        session['s3'] = response.get('s3')
-        return username
 
+    if not username:
+        raise AuthenticationError("Incorrect credentials")
+    if expected_username and username != expected_username:
+        raise AuthenticationError("Usernames don't match")
+    return {
+        'username': username,
+        's3_keys': s3_keys
+    }
+
+def login(email, password):
+    """Authenticates user and returns session"""
+    try:
+        user = authenticate(email=email, password=password)
+        if user:
+            session['username'] = user.get('username')
+            session['s3'] = user.get('s3_keys')
+            return user
     except AuthenticationError:
         return False

--- a/bestbook/api/auth.py
+++ b/bestbook/api/auth.py
@@ -1,4 +1,5 @@
 
+from typing import Dict, Optional
 import requests
 from flask import session
 from internetarchive.config import get_auth_config
@@ -14,10 +15,9 @@ def is_admin(username):
     return '/people/%s' % username in admins
 
 
-def authenticate(email=None, password=None, s3_keys=None, expected_username=None):
+def authenticate(email=None, password=None, s3_keys=None):
     """
     :parm dict s3_keys: a dict {'secret': 'xxx', 'access': 'yyy'}
-    :param str expected_username: expected username for account w/ s3_keys
     """
     username = None
 
@@ -48,8 +48,6 @@ def authenticate(email=None, password=None, s3_keys=None, expected_username=None
 
     if not username:
         raise AuthenticationError("Incorrect credentials")
-    if expected_username and username != expected_username:
-        raise AuthenticationError("Usernames don't match")
     return {
         'username': username,
         's3_keys': s3_keys

--- a/bestbook/templates/ask.html
+++ b/bestbook/templates/ask.html
@@ -1,4 +1,5 @@
 <form action="/ask" method="post">
+  <input type="hidden" name="username" value="{{ session.get('username') }}">
   <div class="block">
     <div class="step step--1">
       <h2>1. ⚖️ What is "<span class="bbo">The Best Book On</span>"</h2>

--- a/bestbook/templates/submit.html
+++ b/bestbook/templates/submit.html
@@ -1,5 +1,6 @@
 
 <form id="recommendations-form" name="recommendations-form" method="POST" action="/submit">
+  <input type="hidden" name="username" value="{{ session.get('username') }}">
   <div class="block">
     <div class="step step--1">
       <div class="picker">

--- a/bestbook/views/__init__.py
+++ b/bestbook/views/__init__.py
@@ -132,16 +132,12 @@ class Section(MethodView):
 
 def require_auth(func):
     def authed_func(*args, **kwargs):
-        # username needs to be added to the front-end forms
-        # as a hidden field (populated by session.get('username')
-        # Note: we may not want to keep username + s3 in request.form
-        username = request.form.get('username')
         s3_keys = {
-            'access': request.form.get('s3_access'),
-            'secret': request.form.get('s3_secret'),
+            'access': request.data.get('s3_access'),
+            'secret': request.data.get('s3_secret'),
         }
         # An auth error will raise AuthenticationError
-        user = authenticate(s3_keys=s3_keys, expected_username=username)
+        user = authenticate(s3_keys=s3_keys)        
         return func(*args, **kwargs)
     return authed_func
 


### PR DESCRIPTION
This splits the `auth.login` method from `auth.authenticate` -- a new method which can take either email/password or s3_keys and return the matching `user` object (namely the associated username)

Open Library observation POST will have to include s3_keys which we can get using:

```
from openlibrary.accounts.model import OpenLibraryAccount
from openlibrary import accounts
user = accounts.get_current_user()
account = OpenLibraryAccount.get_by_email(user.email)
s3_keys = web.ctx.site.store.get(account._key).get('s3_keys')
 ```
 
 see: https://github.com/internetarchive/openlibrary/blob/85391b39c015d3b5f8b5032c3e101132a2737539/openlibrary/plugins/upstream/borrow.py#L135-L140
 
 ## Note
 
TODO: We should probably *always* get the username from the authenticate function results directly, instead of passing in an expected_username (which doesn't really serve any purpose). 

e.g. @jamesachamp, we should probably update this code to use `user = auth.authenticate(s3_access, s3_secret)` to get the username:

```
https://github.com/Open-Book-Genome-Project/TheBestBookOn.com/blob/master/bestbook/views/__init__.py#L211-L221
```
Also, I feel like to avoid the form data getting polluted with fields which aren't required by the models, I/we may want to change this PR so that s3_keys are sent as `headers` rather than form data.

e.g. from Open Library, when we use js to POST to TBBO, we may want to add a new `headers: {'x-s3-secret': 'xxx', 'x-s3-access': 'xxx'}` :
https://github.com/internetarchive/openlibrary/blob/e6d987d2765b3bf0d087df860c8b4da472293b57/openlibrary/plugins/openlibrary/js/patron-metadata/index.js#L50-L54

