### PR TITLE
Require reviews for candidate works

### DIFF
--- a/bestbook/static/build/css/style.css
+++ b/bestbook/static/build/css/style.css
@@ -471,12 +471,14 @@ span[title] {
 
 /* Preview lists */
 #candidate-list,
-#winner-list {
+#winner-list,
+#selection-list {
     list-style: none;
 }
 
 #candidate-list li,
-#winner-list li {
+#winner-list li,
+#selection-list li {
     display: flex;
     justify-content: space-between;
     margin-bottom: 1em;
@@ -503,6 +505,24 @@ span[title] {
 .list-delete {
     cursor: pointer;
     align-self: center;
+}
+
+/* Specific recommendation selection list rules */
+#selection-list {
+    padding-left: 0px;
+}
+
+#selection-list li {
+    display: block;
+    margin-bottom: 1em;
+}
+
+#selection-list .preview-link {
+    margin-bottom: 1em;
+}
+
+.selection-review textarea {
+    width: 100%;
 }
 
 /* Prevents selected items from autocomplete forms from

--- a/bestbook/templates/submit.html
+++ b/bestbook/templates/submit.html
@@ -32,8 +32,9 @@
 
     <div class="step step--3">
       <div class="picker">
-        <h2>3. 📏  Review:</h2>
-        <textarea id="description" type="text" name="description" placeholder="The winner was chosen because..." style="width: 100%" required></textarea>
+        <h2>3. 📏  Reviews:</h2>
+        <p id="no-selections-message">Please select a winner and at least one candidate for review.</p>
+        <ul id="selection-list"></ul>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #70 

__Note:__ This builds on PR #69.  Once that has been merged into master, I'll rebase this and remove the draft state from this PR.

Adds a preview of the winner and each selected candidate work to section three of the recommendation submission form.  Each preview also includes a text area in which a recommender must leave a review of the book.  All reviews are validated before they are submitted to the server.

Reviews of candidates are not persisted.  They are merely sent to the server.  Persisting the reviews can occur once #67 has been merged into master.

![preview_2](https://user-images.githubusercontent.com/28732543/105227943-ec3ddd80-5b2f-11eb-8616-ab28fe247d20.gif)