### PR TITLE
Remove DB session on request end

### DIFF
--- a/bestbook/app.py
+++ b/bestbook/app.py
@@ -15,6 +15,7 @@ from flask_cors import CORS
 from logging.config import dictConfig
 import views
 from views import fetch_work
+from api import db
 from configs import options, SECRET_KEY, LOGGER
 
 urls = ('/admin', views.Admin,
@@ -41,3 +42,8 @@ dictConfig(LOGGER)
 
 if __name__ == "__main__":
     app.run(**options)
+
+@app.teardown_appcontext
+def shutdown_session(exception=None):
+    # Removes db session at the end of each request
+    db.remove()


### PR DESCRIPTION
Closes #47 

Added method that removes the DB session at the end of each request (as per documentation found [here](https://flask.palletsprojects.com/en/1.1.x/patterns/sqlalchemy/#declarative)).

__Note:__ I wasn't able to reproduce the TimeoutError locally before making this change.  The only time that I saw this error in production was before our meetings, when, I'm assuming, most of the attendees visited the site during a short span of time.  A few of us may want to coordinate and try to trigger the error with the new code on one of the development instances before pushing this to production.