### PR TITLE
Update values for fictionality aspect

### DIFF
--- a/bestbook/api/books.py
+++ b/bestbook/api/books.py
@@ -342,7 +342,7 @@ def register_aspects():
            description='Is this book a work of fact or fiction?',
            schema={
                "values": [
-                   "fiction", "nonfiction"
+                   "fiction", "nonfiction", "biography"
                ]
            }
     ).create()


### PR DESCRIPTION
Refs #76 

Adds value "biography" to fictionality aspect in `register_aspects` method.

#76 can be closed once both this PR is merged and the following DML is executed on the production DB:

`UPDATE aspects SET schema = '{"values": ["fiction", "nonfiction", "biography"]}' WHERE label = 'fictionality';`