### PR TITLE
Fetch book's observations given by a single user

### DIFF
--- a/bestbook/views/__init__.py
+++ b/bestbook/views/__init__.py
@@ -251,11 +251,19 @@ class UserObservations(MethodView):
 class BookObservations(MethodView):
     @rest
     def get(self, olid):
-        book = Book(edition_id=olid) if 'M' in olid else Book(work_id=olid)
-        return {
-        "observations": [r.dict() for r in Observation.query.filter(
-            Observation.book_id == book.id).all()]
-        }
+        book = Book.get(edition_olid=olid) if 'M' in olid else Book.get(work_olid=olid, edition_olid=None)
+
+        if request.args.get('username'):
+            return {
+            "observations": [r.dict() for r in Observation.query.filter(
+                Observation.book_id == book.id,
+                Observation.username == request.args.get('username')).all()]
+            }
+        else:
+            return {
+            "observations": [r.dict() for r in Observation.query.filter(
+                Observation.book_id == book.id).all()]
+            }
 
 class Router(MethodView):
 


### PR DESCRIPTION
Closes #57 

Adds ability to include a username in the query string of `/api/books/<OLID>/observations` API calls.  If a username is present, only observations made by the given user for the book will be returned.

This PR also corrects book fetching logic.