### PR TITLE
Fix candidate works persistence bug

### DIFF
--- a/bestbook/api/books.py
+++ b/bestbook/api/books.py
@@ -196,12 +196,16 @@ class Recommendation(core.Base):
         """
         topic = Topic.upsert(topic)
         winner = Book.upsert_by_olid(winner_olid)
+        candidates = []
+        candidates.append(winner)
+        for olid in candidate_olids:
+            candidates.append(Book.upsert_by_olid(olid))
+
         r = cls(topic_id=topic.id, book_id=winner.id,
                 description=description,
-                username=username).create()
-        r.candidates.append(winner)
-        for olid in candidate_olids:
-            r.candidates.append(Book.upsert_by_olid(olid))
+                username=username,
+                candidates=candidates).create()
+
         db.commit()
         return r
 


### PR DESCRIPTION
~~Persists all reviews (candidates and winner) in the `reviews` table~~.  Also corrects bug where candidate books are not always being persisted in the `recommendations_to_books` table.

~~If a work is being reviewed by a user for a second time, the original review is overwritten by the new review.  This may be undesirable if somebody chooses a book as the best for topic A, but decides that the same book is a candidate for topic B.  I think that we discussed this before, but I forget where we landed.  Maybe `topic.id` should be a part of the review's primary key as well, since it will change the context of the review?~~