### PR TITLE
Fix /browse bugs

### DIFF
--- a/bestbook/api/books.py
+++ b/bestbook/api/books.py
@@ -184,7 +184,7 @@ class Recommendation(core.Base):
         for r in recs:
             for c in r.candidates:
                 olids.append(c.work_olid)
-        recs.works = Book.get_many(olids) if olids else []
+        recs.works = Book.get_many(olids) if olids else {}
         return recs
 
     @classmethod

--- a/bestbook/api/books.py
+++ b/bestbook/api/books.py
@@ -184,7 +184,7 @@ class Recommendation(core.Base):
         for r in recs:
             for c in r.candidates:
                 olids.append(c.work_olid)
-        recs.works = Book.get_many(olids)
+        recs.works = Book.get_many(olids) if olids else []
         return recs
 
     @classmethod

--- a/bestbook/templates/browse.html
+++ b/bestbook/templates/browse.html
@@ -10,8 +10,12 @@
 {% for rec in recs %}
 <div class="block">
   <div class="recommendation">
-    <div><a href="https://openlibrary.org/works/{{rec.winner.work_olid}}">
-	<img src="{{recs.works[rec.winner.work_olid].get('cover_url')}}"></a>
+    <div>
+      <a href="https://openlibrary.org/works/{{rec.winner.work_olid}}">
+        {% if recs.works[rec.winner.work_olid].get('cover_url') %}
+        <img src="{{recs.works[rec.winner.work_olid].get('cover_url')}}">
+        {% endif %}
+      </a>
     </div>
     <div>
       <p>The best book on: "{{ rec.topic.name }}" by {{ rec.username }}:</p>


### PR DESCRIPTION
This fixes two new `/browse` bugs:

1. Corrects a bug in which `Section.get()` attempts to render a "None.html" template.  This appears to happen when the response of the Open Library `get_many` call does not have a `cover_url`.  In these cases, the `resource` parameter of `Section.get()` is equal to the string "None" (instead of the value `None`).  
2. If the Open Library `get_many` call returns a 500 response, a JSON encoding error will be thrown when `Book.get_many()` attempts to return a value.

For bug 1, checking for `cover_url` before displaying the book cover solves the issue.  In the future, we may want to add a placeholder image for works that have no cover image.

Bug 2 was corrected by checking for OLIDs before making the `Book.get_many()` call.  