### PR TITLE
Always show admin navigation links to admin users

### DIFF
--- a/bestbook/app.py
+++ b/bestbook/app.py
@@ -16,6 +16,7 @@ from logging.config import dictConfig
 import views
 from views import fetch_work
 from api import db
+from api.auth import is_admin
 from configs import options, SECRET_KEY, LOGGER
 
 urls = ('/admin', views.Admin,
@@ -39,7 +40,7 @@ app = router(Flask(__name__), urls)
 app.secret_key = SECRET_KEY
 cors = CORS(app)
 
-app.jinja_env.globals.update(fetch_work=fetch_work)
+app.jinja_env.globals.update(fetch_work=fetch_work, is_admin=is_admin)
 dictConfig(LOGGER)
 
 if __name__ == "__main__":

--- a/bestbook/templates/base.html
+++ b/bestbook/templates/base.html
@@ -41,15 +41,15 @@
         <!-- Add your site or application content here -->
         <div class="container">
           <span class="navigation">
-            {% if not request.path.startswith('/admin') %}
-              <a class="filter {{'selected' if request.path in ['/browse', '/'] else ''}}" href="/browse">Browse</a>,
-              {% if not session.get('username') %}
-              or <a href="/login">login</a> to
-              {% endif %}
-              <!-- <a class="filter {{'selected' if request.path in ['/ask', '/'] else ''}}" href="/ask">Request</a>, or -->
-              <a class="filter {{'selected' if request.path in ['/ask'] else ''}}" href="https://forms.gle/FQGbrTNY3kYfPoAA6" target="_blank">Request</a>, or
-              <a class="filter {{'selected' if request.path == '/submit' else ''}}" href="/submit">Make</a> Recommendations.
-            {% else %}
+            <a class="filter {{'selected' if request.path in ['/browse', '/'] else ''}}" href="/browse">Browse</a>,
+            {% if not session.get('username') %}
+            or <a href="/login">login</a> to
+            {% endif %}
+            <!-- <a class="filter {{'selected' if request.path in ['/ask', '/'] else ''}}" href="/ask">Request</a>, or -->
+            <a class="filter {{'selected' if request.path in ['/ask'] else ''}}" href="https://forms.gle/FQGbrTNY3kYfPoAA6" target="_blank">Request</a>, or
+            <a class="filter {{'selected' if request.path == '/submit' else ''}}" href="/submit">Make</a> Recommendations.
+            <br>
+            {% if session.get('username') and is_admin(session.get('username')) %}
               <a class="filter {{'selected' if request.path in ['/admin'] else ''}}" href="/admin">Debug</a>
               <a class="filter {{'selected' if request.path in ['/admin/approve/recommendations'] else ''}}" href="/admin/approve/recommendations">Approve Recommendations</a>
               <a class="filter {{'selected' if request.path in ['/admin/approve/requests'] else ''}}" href="/admin/approve/requests">Approve Requests</a>


### PR DESCRIPTION
Closes: #54

Exposes `is_admin()` to templates and displays admin links to logged in admin users. Browse, request, and make recommendation links are also now present in admin pages.

![admin_navbar](https://user-images.githubusercontent.com/28732543/110177562-2955ea80-7dd3-11eb-9f5a-283df29a7a85.png)

