### PR TITLE
Display only approved recommendations on /browse

### DIFF
--- a/bestbook/api/books.py
+++ b/bestbook/api/books.py
@@ -178,9 +178,9 @@ class Recommendation(core.Base):
     candidates = relationship("Book", secondary='recommendations_to_books')
 
     @classmethod
-    def paginate(cls, page, limit=10):
+    def paginate(cls, page, limit=10, **kwargs):
         olids = []
-        recs = cls.query.filter().limit(limit).offset(page * limit)
+        recs = cls.query.filter_by(**kwargs).limit(limit).offset(page * limit)
         for r in recs:
             for c in r.candidates:
                 olids.append(c.work_olid)

--- a/bestbook/templates/browse.html
+++ b/bestbook/templates/browse.html
@@ -5,7 +5,7 @@
 <!-- send all of their book keys to Open Library -->
 
 {% set page = request.args.get("page", 0) | int %}
-{% set recs = models["recommendations"].paginate(page) %}
+{% set recs = models["recommendations"].paginate(page, is_approved=True) %}
 
 {% for rec in recs %}
 <div class="block">


### PR DESCRIPTION
Closes #39 

Adds key word arguments to `Recommendation.paginate()`, allowing results to be filtered by some criteria.  Paginate call in the `/browse` view updated to return only approved recommendations.

Setting this PR as a draft until either some legitimate recommendations have been approved in the production DB, or until #51 is closed (this may block `/browse` page styling if merged too soon).