### PR TITLE
Check for Open Library API call failures in Book.get_many()

### DIFF
--- a/bestbook/api/books.py
+++ b/bestbook/api/books.py
@@ -87,6 +87,12 @@ class Book(core.Base):
     def get_many(olids):
         url = 'https://dev.openlibrary.org/get_many?ids=' + ','.join(olids)
         r = requests.get(url)
+
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            return {}
+
         return r.json()
 
     @staticmethod

--- a/bestbook/templates/browse.html
+++ b/bestbook/templates/browse.html
@@ -12,7 +12,7 @@
   <div class="recommendation">
     <div>
       <a href="https://openlibrary.org/works/{{rec.winner.work_olid}}">
-        {% if recs.works[rec.winner.work_olid].get('cover_url') %}
+        {% if recs.works|length > 0 and recs.works[rec.winner.work_olid].get('cover_url') %}
         <img src="{{recs.works[rec.winner.work_olid].get('cover_url')}}">
         {% endif %}
       </a>


### PR DESCRIPTION
Closes: #92

`Book.get_many()` now returns an empty dictionary when the Open Library API call fails.  In order to avoid a Jinja error in these cases, the length of `recs.works` is now checked before accessing the cover URL in the template.

This will cause merge conflicts with some other branches (PRs #93 and #94), so I'm setting this as a draft until they are merged.  Will make the necessary changes to this PR at that time.