### PR TITLE
Remove candidate review text areas

### DIFF
--- a/bestbook/static/build/css/style.css
+++ b/bestbook/static/build/css/style.css
@@ -523,6 +523,7 @@ span[title] {
 
 .selection-review textarea {
     width: 100%;
+    margin-bottom: 1em;
 }
 
 /* Aspect review inputs */

--- a/bestbook/static/build/js/index.js
+++ b/bestbook/static/build/js/index.js
@@ -90,7 +90,6 @@ $( function() {
       title: title,
       image: image,
       olid: olid,
-      review: ''
     };
     candidates.push(candidate);
 
@@ -171,19 +170,24 @@ $( function() {
    */
   function addReviewListItem(book, isWinner) {
     var listItemMarkUp = `
-    <li>
+      <li> 
+    `;
+
+    if(isWinner) {
+      listItemMarkUp += `
+        <div class="selection-review">
+          <textarea id="description" type="text" name="selection" placeholder="The winner was chosen because..." required></textarea>
+        </div>
+      `;
+    }
+    listItemMarkUp += `
       <div class="selection-info">
         <a class="preview-link" href="https://openlibrary.org${book.olid}" target="_blank">
           <img src="${book.image}"><span class="book-title">${book.title}</span>
         </a>
       </div>
-      <div class="selection-review">
+      <div>
     `;
-    if(isWinner) {
-      listItemMarkUp += ' <textarea id="description" type="text" name="selection" placeholder="The winner was chosen because..." required></textarea>';
-    } else {
-      listItemMarkUp += ` <textarea id="candidate-review${candidateIndex}" class="candidate-review" type="text" name="selection" placeholder="${book.title} was a candidate because..." required></textarea>`;
-    }
 
     var observationId = (isWinner) ? "best-book-observations" : `candidate-observations-${candidateIndex}`;
 
@@ -398,15 +402,12 @@ $( function() {
     $(this).on('submit', function(event) {
       event.preventDefault()
 
-      setCandidateReviews();
       setObservations();
 
       formData.candidates = [];
-      formData.reviews = [];
 
       for(var i = 0; i < candidates.length; ++i) {
         formData.candidates.push(candidates[i].olid);
-        formData.reviews.push(candidates[i].review);
       }
 
       let $description = $('#description');
@@ -538,12 +539,6 @@ $( function() {
     
     for (const candidate of formData.candidates) {
       if(!validOlidRe.test(candidate)) {
-        return false;
-      }
-    }
-
-    for (const review of formData.reviews) {
-      if(!review.length) {
         return false;
       }
     }

--- a/bestbook/static/build/js/index.js
+++ b/bestbook/static/build/js/index.js
@@ -460,22 +460,6 @@ $( function() {
   }
 
   /**
-   * Adds each review to its respective candidate object.
-   * 
-   * If any textarea contains a string of only whitespace characters, that string
-   * is replaced by an empty string.
-   */
-  function setCandidateReviews() {
-    var $reviewTextAreas = $('.candidate-review');
-    $reviewTextAreas.each(function(index) {
-      // Sets whitespace only review to an empty string, 
-      // which will trigger UI hint from browser
-      $(this).val($(this).val().trim());
-      candidates[index].review = $(this).val();
-    });
-  }
-
-  /**
    * Stores the names and values of all observations in each review.
    * 
    * Composes an observation object for each review section in the form.


### PR DESCRIPTION
Closes: #97 

Removes all candidate review fields, leaving only one for the entire set of books included in the recommendation.

![single_review_field](https://user-images.githubusercontent.com/28732543/110227774-bed3a600-7ec9-11eb-9aad-73a3806f525d.png)
