### PR TITLE
Clean OLID when creating new book

### DIFF
--- a/bestbook/views/__init__.py
+++ b/bestbook/views/__init__.py
@@ -208,9 +208,9 @@ class Observations(MethodView):
                 edition_olid=Book.clean_olid(data.get('edition_id'))
             )
         except RexException:
-            book = Book(work_olid=data['work_id'])
+            book = Book(work_olid=Book.clean_olid(data['work_id']))
             if 'edition_id' in data:
-                book.edition_olid = data['edition_id']
+                book.edition_olid = Book.clean_olid(data['edition_id'])
 
             book.create()
 


### PR DESCRIPTION
Previous pull request for this issue only cleaned the OLIDs when querying for an existing book.  This one cleans the OLIDs when a new book is created.