### PR TITLE
Correct missing observations in recommendation POSTs

### DIFF
--- a/bestbook/static/build/js/index.js
+++ b/bestbook/static/build/js/index.js
@@ -475,7 +475,7 @@ $( function() {
     var $observationSections = $('.observations');
 
     $observationSections.each(function(index) {
-      observationsObject = {};
+      let observationsObject = {};
       observationsObject.observations = [];
 
       $(this).find('input[type=radio]:checked').each(function() {

--- a/bestbook/static/build/js/index.js
+++ b/bestbook/static/build/js/index.js
@@ -240,7 +240,7 @@ $( function() {
         var choiceId = `${id}-${aspectList[i].label}-${j}`;
         aspectMarkup += `
           <label class="${className}-label" for="${choiceId}">
-            <input type="${aspectList[i].multi_choice ? 'checkbox' : 'radio'}" name="${aspectList[i].label}" id="${choiceId}" value="${aspectList[i].schema.values[j]}">
+            <input type="${aspectList[i].multi_choice ? 'checkbox' : 'radio'}" name="${aspectList[i].label}-${id}" id="${choiceId}" value="${aspectList[i].schema.values[j]}">
             ${aspectList[i].schema.values[j]}
           </label>
         `
@@ -480,13 +480,13 @@ $( function() {
 
       $(this).find('input[type=radio]:checked').each(function() {
         var keyValuePair = {};
-        keyValuePair[$(this).attr('name')] = $(this).val();
+        keyValuePair[$(this).attr('name').split('-')[0]] = $(this).val();
         observationsObject.observations.push(keyValuePair);
       });
 
       $(this).find('input[type=checkbox]:checked').each(function() {
         var keyValuePair = {};
-        keyValuePair[$(this).attr('name')] = $(this).val();
+        keyValuePair[$(this).attr('name').split('-')[0]] = $(this).val();
         observationsObject.observations.push(keyValuePair);
       });
 


### PR DESCRIPTION
The `name` attribute was not unique for different radio button groups (for example, the pace radio buttons for the winner had the same name as the pace radio buttons for each of the candidates).  Selecting a single-choice observation for one book would cause the same type of observation to be deselected for all other books.

This PR ensures that a unique ID is included at the end of the `name` for each radio and checkbox group (e.g. `pace-best-book-observations`, `pace-candidate-observations-1`, etc).

Also, the `observationsObject` variable has now been properly defined with `let`.  This wasn't causing any issues, but leaving it unchanged could potentially create a difficult to diagnose bug in the future.