### PR TITLE
bestbook style.css: fix sticky scrolling

### DIFF
--- a/bestbook/static/build/css/style.css
+++ b/bestbook/static/build/css/style.css
@@ -6,6 +6,13 @@ html, body {
     font-size: 1.3em;
 }
 
+html {
+    overflow: hidden;
+}
+body {
+    overflow: auto;
+}
+
 h1, h2, h3 {
     font-family: 'Playfair Display', serif;
 }


### PR DESCRIPTION
Before when scrolling down the page, the header bar would not remain sticky because of the body overflow. Now it does.


## Before
![2021-05-24 15 27 06](https://user-images.githubusercontent.com/1366208/119414551-9e371300-bca4-11eb-80a6-ea77eaf30c69.gif)


## After
![2021-05-24 15 28 34](https://user-images.githubusercontent.com/1366208/119414634-c32b8600-bca4-11eb-9c17-ecbc525b7332.gif)
