### PR TITLE
Require confirmation on recommendation delete

### DIFF
--- a/bestbook/static/build/css/style.css
+++ b/bestbook/static/build/css/style.css
@@ -464,6 +464,13 @@ span[title] {
     background-color: red;
 }
 
+.btn-danger-confirm {
+    transition: all 0.5s;
+    color: red;
+    background-color: #fff;
+    border: red 1px solid;
+}
+
 .btn-success {
     color: #fff;
     background-color: green;
@@ -481,6 +488,7 @@ span[title] {
     justify-content: flex-end;
     padding-bottom: .8em;
     margin-left: .5em;
+    width: 12%;
 }
 
 .approval-item-buttons button {

--- a/bestbook/static/build/js/index.js
+++ b/bestbook/static/build/js/index.js
@@ -660,14 +660,25 @@ function approveRecommendation(recommendationId) {
   })
 }
 
-function rejectRecommendation(recommendationId) {
-  $.ajax({
-    type: 'DELETE',
-    url: `/api/recommendations/${recommendationId}`,
-    success: function(msg) {
-      updateButtonGroup(recommendationId, msg);
-    }
-  })
+function rejectRecommendation(button, recommendationId) {
+
+  if (button.classList.contains('btn-danger-confirm')) {
+    $.ajax({
+      type: 'DELETE',
+      url: `/api/recommendations/${recommendationId}`,
+      success: function(msg) {
+        updateButtonGroup(recommendationId, msg);
+      }
+    })
+  } else {
+    button.classList.add('btn-danger-confirm');
+    button.classList.remove('btn-danger')
+    setTimeout(function() {
+      button.textContent = "Confirm";
+    }, 450)
+    
+  }
+
 }
 
 function updateButtonGroup(id, msg) {

--- a/bestbook/templates/approve-recommendation.html
+++ b/bestbook/templates/approve-recommendation.html
@@ -20,7 +20,7 @@
     {% if session.get('username') %}
     <div class="approval-item-buttons" id="button-group-{{ recommendation['id'] }}">
         <button class="btn btn-success" onclick="approveRecommendation( {{ recommendation['id'] }} )">Accept</button>
-        <button class="btn btn-danger" onclick="rejectRecommendation( {{ recommendation['id'] }} )">Reject</button>
+        <button class="btn btn-danger" onclick="rejectRecommendation( this, {{ recommendation['id'] }} )">Reject</button>
         <!-- <button class="btn btn-primary">Request Clarification</button> -->
     </div>
     {% endif %}


### PR DESCRIPTION
Closes #111

Requires reviewer to click the reject button twice in order to reject a recommendation.

![confirm-delete](https://user-images.githubusercontent.com/28732543/120415399-780b1600-c329-11eb-8d79-9e2213e7a04c.gif)

**Stakeholders:**
@laurenwm