### PR TITLE
Simplify recommendation form

### DIFF
--- a/bestbook/static/build/css/style.css
+++ b/bestbook/static/build/css/style.css
@@ -648,50 +648,6 @@ span[title] {
     margin-bottom: 1em;
 }
 
-/* Aspect review inputs */
-.aspect-category {
-    text-transform: capitalize;
-}
-
-.aspect-description {
-    font-size: .8em;
-    margin: 0 0 .8em .4em;
-}
-
-.multi-choice {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-.multi-choice-label {
-    flex: 0 0 25%;
-    margin: .5em 0;
-    text-transform: capitalize;
-    font-size: .8em;
-}
-
-.multi-choice input {
-    margin-right: .3em;
-}
-
-.single-choice {
-    display: flex;
-}
-
-.single-choice input {
-    display: block;
-    margin: 0 auto 5px;
-}
-
-.single-choice-label {
-    display: inline-block;
-    text-align: center;
-    text-transform: capitalize;
-    width: 16%;
-    font-size: .8em;
-    margin-right: .4em;
-}
-
 /* Prevents selected items from autocomplete forms from
 being rendered at the bottom of the page */
 .ui-helper-hidden-accessible {
@@ -739,33 +695,7 @@ being rendered at the bottom of the page */
 }
 
 /* Collapsible sections */
-.collapsible {
-    cursor: pointer;
-    padding: .5em;
-    margin: .5em 0;
-}
 
-.collapsible:after {
-    content: "\02795";
-    float: right;
-    padding-right: 18px;
-}
-
-.active,
-.collapsible:hover {
-    background-color: hsla(206, 51%, 26%, .25);
-}
-
-.active:after {
-    content: "\2796";
-}
-
-.collapsible-content {
-    padding: 0 .5em;
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.2s ease-out;
-}
 
 /* Aspect review outputs */
 aspect-label {

--- a/bestbook/static/build/js/index.js
+++ b/bestbook/static/build/js/index.js
@@ -29,26 +29,33 @@ $( function() {
     },
   };
 
+  /* START: Code for /submit view: */
   var formData = {};
   var winner = {}
-
   var candidates = [];
   var candidateIndex = 0;
 
-  var observations = [];
+  /**
+   * Toggles visibility of review textarea and related help message
+   * 
+   * Ensures that only the textarea or the help message is visible at a time. Clears
+   * textarea before displaying to readers.
+   * 
+   * @param {boolean} textAreaVisible True if the review text area should be displayed
+   */
+  function showReviewTextArea(textAreaVisible) {
+    let reviewContainer = document.querySelector('#winner-review')
+    let textArea = document.querySelector('#description')
+    let warningMessage = document.querySelector('#no-selections-message')
 
-  var $noSelectionMessage = $('#no-selections-message');
-
-  var aspects;
-
-  if (window.location.pathname === '/submit') {
-    $.ajax({
-      type: 'GET',
-      url: '/api/aspects',
-      success: function(data) {
-        aspects = data.aspects;
-      }
-    });
+    if (textAreaVisible) {
+      textArea.value = '';
+      reviewContainer.hidden = false;
+      warningMessage.hidden = true;
+    } else {
+      reviewContainer.hidden = true;
+      warningMessage.hidden = false;
+    }
   }
 
   function selectBestBook(title, image, olid) {
@@ -57,7 +64,7 @@ $( function() {
     winner = {
       title: title,
       image: image,
-      olid: olid
+      olid: olid  // This is actually the key (`/works/${work_olid}`)
     };
 
     var bestBookListItem = `
@@ -71,29 +78,27 @@ $( function() {
       </li>`;
 
       $('#winner-list').append(bestBookListItem);
-      $('#winner').prop('hidden', true);
+      $('#winner').prop('hidden', true);  // Hide text input for winner search
 
-      // Add to selection list
-      addReviewListItem(winner, true);
-      $noSelectionMessage.prop('hidden', true);
+      addSelectedListItem(winner, true);
+
+      if (candidates.length > 0) {
+        showReviewTextArea(true);
+      }
 
       $('#best-book-delete').on('click', function() {
         $(this).parent().remove();
-        $winner = $('#winner');
+        $(`#list-item-${winner.olid.split('/').pop()}`).remove();
+
+        $winner = $('#winner'); // References text input for winner search
         $winner.val('');
         $winner.prop('hidden', false);
         delete formData['winner'];
         winner = {};
 
-        // remove from selection list
-        $('#description').parent().parent().remove();
-
-        if(!candidates.length) {
-          $noSelectionMessage.prop('hidden', false);
-        }
+        showReviewTextArea(false);
       })
   }
-
 
   function selectCandidateWork(title, image, olid) {
     // Store candidate data
@@ -101,7 +106,7 @@ $( function() {
       id: ++candidateIndex,
       title: title,
       image: image,
-      olid: olid,
+      olid: olid, // This is actually the key (`/works/${work_olid}`)
     };
     candidates.push(candidate);
 
@@ -111,7 +116,7 @@ $( function() {
         <a class="preview-link" href="https://openlibrary.org${candidate.olid}" target="_blank">
           <img src="${candidate.image}"><span class="book-title">${candidate.title}</span>
         </a>
-        <span id="list-delete${candidateIndex}" class="list-delete">
+        <span id="list-delete-${candidateIndex}" class="list-delete">
         &times;
         </span>
       </li>`;
@@ -119,18 +124,17 @@ $( function() {
     $('#candidate-list').append(listItem);
 
     // Add to selection review list
-    addReviewListItem(candidate, false);
-    $noSelectionMessage.prop('hidden', true);
+    addSelectedListItem(candidate, false);
+    if (!$.isEmptyObject(winner)) {
+      showReviewTextArea(true);
+    }
 
     // Add delete listener
-    $(`#list-delete${candidateIndex}`).on('click', function() {
-      
+    $(`#list-delete-${candidateIndex}`).on('click', function() {
       deleteListItem($(this).parent());
-
-      // Remove from selection review list
-      $(`#candidate-review${candidate.id}`).parent().parent().remove();
-      if(!candidates.length && $.isEmptyObject(winner)) {
-        $noSelectionMessage.prop('hidden', false);
+      $(`#list-item-${candidate.olid.split('/').pop()}`).remove();
+      if(!candidates.length || $.isEmptyObject(winner)) {
+        showReviewTextArea(false);
       }
     });
 
@@ -164,158 +168,33 @@ $( function() {
   }
 
   /**
-   * Adds a selected work to the book review list.
+   * Adds a new selected work to list of all selected works.
    * 
    * Creates and displays a new selected work review list item.  List item
-   * contains a section with the book's title and cover image (if available),
-   * and a review section.
-   * 
-   * Each review section contains a free-form textarea for a review, and a 
-   * collapsible section that contains several predefined observations that
-   * can improve the review.
+   * contains a section with the book's title and cover image (if available).
    * 
    * Books that are desginated as the best book on a subject will appear first
    * in the list.
    * 
    * @param {Object}  book      Contains book title, cover image, and OLID.
-   * @param {boolean} isWinner  True if the book is the best book on a subject.
+   * @param {boolean} isWinner  True if the book is chosen as the best book on a subject.
    */
-  function addReviewListItem(book, isWinner) {
+  function addSelectedListItem(book, isWinner) {
+    let olid = book.olid.split('/').pop();
     var listItemMarkUp = `
-      <li> 
-    `;
-
-    if(isWinner) {
-      listItemMarkUp += `
-        <div class="selection-review">
-          <textarea id="description" type="text" name="selection" placeholder="The winner was chosen because..." required></textarea>
+      <li id="list-item-${olid}"> 
+        <div class="selection-info">
+          <a class="preview-link" href="https://openlibrary.org${book.olid}" target="_blank">
+            <img src="${book.image}"><span class="book-title">${book.title}</span>
+          </a>
         </div>
-      `;
-    }
-    listItemMarkUp += `
-      <div class="selection-info">
-        <a class="preview-link" href="https://openlibrary.org${book.olid}" target="_blank">
-          <img src="${book.image}"><span class="book-title">${book.title}</span>
-        </a>
-      </div>
-      <div>
-    `;
-
-    var observationId = (isWinner) ? "best-book-observations" : `candidate-observations-${candidateIndex}`;
-
-    listItemMarkUp += `
-      ${addObservationSection(aspects, observationId)}
-      </div>
-    </li>
-    `
+      </li>`
 
     if(isWinner) {
       $('#selection-list').prepend(listItemMarkUp);
     } else {
       $('#selection-list').append(listItemMarkUp);
     }
-
-    addCollapsibleListeners();
-  }
-
-  /**
-   * Creates markup for collapsible set of predefined observation inputs.
-   * 
-   * All observations nested inside of a single collapsible element, and each
-   * observation is itself collapsible.  An observation consists of a category
-   * that expands into a question with a set of predefined answers, displayed as
-   * either radio buttons or checkboxes. 
-   * 
-   * @param {Array<Object>} aspectList  A list of Aspect objects.
-   * @param {String} id                 A string that uniquely identifies an aspect.
-   * 
-   * @return {String} A string containing the HTML markup of the observations section.
-   */
-  function addObservationSection(aspectList, id) {
-    var aspectMarkup = `
-      <div class="collapsible">Additional Observations (Highly recommended):</div>
-      <div class="collapsible-content nested observations">
-    `;
-
-    for(var i = 0; i < aspectList.length; ++i) {
-      var className = aspectList[i].multi_choice ? "multi-choice" : "single-choice";
-
-      aspectMarkup += `
-        <div class="collapsible aspect-category">${aspectList[i].label}</div>
-        <div class="collapsible-content">
-          <div class="aspect-description">${aspectList[i].description}</div>
-          <div class="${className}">
-      `;
-
-
-      for(var j = aspectList[i].schema.values.length - 1; j >= 0; --j) {
-        var choiceId = `${id}-${aspectList[i].label}-${j}`;
-        aspectMarkup += `
-          <label class="${className}-label" for="${choiceId}">
-            <input type="${aspectList[i].multi_choice ? 'checkbox' : 'radio'}" name="${aspectList[i].label}-${id}" id="${choiceId}" value="${aspectList[i].schema.values[j]}">
-            ${aspectList[i].schema.values[j]}
-          </label>
-        `
-      }
-
-      aspectMarkup += `
-          </div>
-        </div>
-      `;
-    }
-
-    aspectMarkup += "</div>"
-    return aspectMarkup;
-  }
-
-  /**
-   * Handles clicks on a collapsible element.
-   * 
-   * Toggles the "active" class on the collapible that was clicked, highlighting
-   * expanded section headings.  Resizes the maximum height of the collapsible 
-   * content divs, and the parenet element if necessary.
-   * 
-   * @param {ClickEvent} event
-   */
-  function collapseHandler(event) {
-    this.classList.toggle("active");
-    var content = this.nextElementSibling;
-
-    if(content.style.maxHeight) {
-      content.style.maxHeight = null;
-    } else {
-      if(content.parentElement.classList.contains("nested")) {
-        adjustMaxHeight(content.parentElement, content.scrollHeight);
-      }
-
-      content.style.maxHeight = content.scrollHeight + "px";
-    }
-  }
-
-  /**
-   * Adds a collapsible handler to all collapsible elements.
-   */
-  function addCollapsibleListeners() {
-    var collapsibles = document.getElementsByClassName("collapsible");
-
-    for(var i = 0; i < collapsibles.length; ++i) {
-      collapsibles[i].addEventListener("click", collapseHandler);
-    }
-
-  }
-
-  /**
-   * Resizes the given element by its scroll height plus an additional amount.
-   * 
-   * This function is used to resize a parent element when one of its collapsible
-   * children are expanded.  The additional height should be equal to the child's scroll
-   * height.
-   * 
-   * @param {HTMLElement} element     The element being resized
-   * @param {Number} additionalHeight Additional amount by which to resize the element.
-   */
-  function adjustMaxHeight(element, additionalHeight) {
-    element.style.maxHeight = (element.scrollHeight + additionalHeight) + "px";
   }
 
   /* This is the main function which registers a <input class="ui-widget">
@@ -414,8 +293,6 @@ $( function() {
     $(this).on('submit', function(event) {
       event.preventDefault()
 
-      setObservations();
-
       formData.candidates = [];
 
       for(var i = 0; i < candidates.length; ++i) {
@@ -432,25 +309,6 @@ $( function() {
       }
 
       if(validateRecommendationFormData()) {
-        formData.observations = [];
-
-        // Set work OLID for each observation
-        for(var i = 0; i < observations.length; ++i) {
-          // Check that observations array has at least one observation:
-          if(observations[i].observations.length) {
-            var currentObservation = observations[i];
-
-            // Best book will be in the first index
-            if(i === 0){
-              currentObservation.work_id = winner.olid;
-            } else {
-              currentObservation.work_id = candidates[i - 1].olid;
-            }
-
-            formData.observations.push(JSON.stringify(currentObservation));
-          }
-        }
-        
         // TODO: Handle failure cases (server error)
         $.ajax({
           type: 'POST',
@@ -469,41 +327,6 @@ $( function() {
         displayModal(header, body);
       }
     })
-  }
-
-  /**
-   * Stores the names and values of all observations in each review.
-   * 
-   * Composes an observation object for each review section in the form.
-   * Observation objects include key value pairs for each of the checked
-   * inputs in a section, with the keys being the value of the Aspect's
-   * label field.
-   * 
-   * Observation objects are stored in the `observations` array in the order
-   * that they appear in the form.
-   */
-  function setObservations() {
-    observations = [];
-    var $observationSections = $('.observations');
-
-    $observationSections.each(function(index) {
-      let observationsObject = {};
-      observationsObject.observations = [];
-
-      $(this).find('input[type=radio]:checked').each(function() {
-        var keyValuePair = {};
-        keyValuePair[$(this).attr('name').split('-')[0]] = $(this).val();
-        observationsObject.observations.push(keyValuePair);
-      });
-
-      $(this).find('input[type=checkbox]:checked').each(function() {
-        var keyValuePair = {};
-        keyValuePair[$(this).attr('name').split('-')[0]] = $(this).val();
-        observationsObject.observations.push(keyValuePair);
-      });
-
-      observations[index] = observationsObject;
-    });
   }
 
   /**
@@ -538,6 +361,9 @@ $( function() {
         return false;
       }
     }
+
+    // TODO: Check for presence of winner olid in candidates array.
+    // TODO: Check for duplicate works in candidates array (Optional, but should be handled server-side if not here)
 
     return true;
   }
@@ -618,9 +444,13 @@ $( function() {
       return renderItem.call(this, ul, item);
     }
   }
+
+  /* END: Code for /submit view: */
 });
 
-/* Admin functions: */
+/* START: Code for /admin views: */
+// TODO: Should these functions really be public?
+
 function approveRequest(requestId) {
   let payload = { approved: true }
 
@@ -633,7 +463,6 @@ function approveRequest(requestId) {
       updateButtonGroup(requestId, msg);
     }
   })
-
 }
 
 function rejectRequest(requestId) {
@@ -675,3 +504,4 @@ function updateButtonGroup(id, msg) {
   div.children().hide()
   div.append(`<p>${msg}</p>`)
 }
+/* END: Code for /admin views: */

--- a/bestbook/templates/submit.html
+++ b/bestbook/templates/submit.html
@@ -42,6 +42,9 @@
       <div class="picker">
         <h2> 📏  Evaluation:</h2>
         <p id="no-selections-message">Please select a winner and at least one candidate for review.</p>
+        <div id="winner-review" class="selection-review" hidden>
+          <textarea id="description" type="text" name="selection" placeholder="The winner was chosen because..." required></textarea>
+        </div>
         <ul id="selection-list"></ul>
       </div>
     </div>


### PR DESCRIPTION
This PR removes the concept of observations and aspects from the front-end recommendation form template and its corresponding JS code.

Also removes review text areas for candidate works.

Submissions are still successful when testing locally.

**Screenshot of evaluation section:**

![Screenshot from 2021-11-10 17-27-41](https://user-images.githubusercontent.com/28732543/141204258-af13d142-990a-4461-8cda-150891fb255a.png)

TODO:
- [ ] In evaluation section, identify best book (or remove all books from this section --- discussion required)

