### PR TITLE
Fix Review properties

### DIFF
--- a/bestbook/api/books.py
+++ b/bestbook/api/books.py
@@ -127,19 +127,11 @@ class Review(core.Base):
 
     @hybrid_property
     def winner(self):
-        return fetch_work(self.nodes[0].winner_work_olid)
-
-    @hybrid_property
-    def winner_olid(self):
-        return self.nodes[0].winner_work_olid
+        return fetch_work(self.winner_work_olid)
 
     @hybrid_property
     def contenders(self):
         return get_many([n.contender_work_olid for n in self.nodes])
-
-    @hybrid_property
-    def submitter(self):
-        return self.nodes[0].submitter
 
     def delete_nodes(self):
         for n in self.nodes:
@@ -153,11 +145,12 @@ class Review(core.Base):
         :winner_olid: ANY OL ID (e.g. OL123M or OL234W)
         """
         topic = Topic.upsert(topic) # TODO: Is this necessary?
-        review = cls(review=description.strip()).create()
+        cleaned_winner_olid = clean_olid(winner_olid)
+        review = cls(review=description.strip(), submitter=username, winner_work_olid=cleaned_winner_olid).create()
 
         for olid in candidate_olids:
             olid = clean_olid(olid)
-            BookGraph(submitter=username, winner_work_olid=winner_olid,
+            BookGraph(submitter=username, winner_work_olid=cleaned_winner_olid,
                 contender_work_olid=olid, topic_id=topic.id,
                 review_id=review.id
             ).create()

--- a/bestbook/templates/browse.html
+++ b/bestbook/templates/browse.html
@@ -8,7 +8,7 @@
 {% for rev in revs %}
 <div class="block-rec">
   <div class="recommendation">
-    {% set winner = revs.works[rev.nodes[0].winner_work_olid] if rev.nodes[0].winner_work_olid in revs.works else {} %}
+    {% set winner = revs.works[rev.winner_work_olid] if rev.winner_work_olid in revs.works else {} %}
     <div class="recommendation--upvote">
       {% set my_vote = votes.get('user', {}).get(rev.id) %}
       <form method="POST" action="/api/recommendations/{{rev.id}}/votes">
@@ -23,15 +23,15 @@
     </div>
     <div class="recommendation--container">
       <div class="recommendation--title">
-        <p>according to <a href="https://openlibrary.org/people/{{ rev.nodes[0].submitter }}">{{rev.nodes[0].submitter}}</a> on {{rev.created.strftime('%Y-%m-%d')}}</p>
+        <p>according to <a href="https://openlibrary.org/people/{{ rev.submitter }}">{{rev.submitter}}</a> on {{rev.created.strftime('%Y-%m-%d')}}</p>
         <h3>
-          The best book on <strong>{{ rev.nodes[0].topic.name }}</strong> is:
+          The best book on <strong>{{ rev.topic.name }}</strong> is:
         </h3>
       </div>
       <div class="recommendation--body">
         <div class="recommendation--winner">
           <div>
-            <a title="{{winner.title}}" href="https://openlibrary.org/works/{{rev.nodes[0].winner_work_olid}}">
+            <a title="{{winner.title}}" href="https://openlibrary.org/works/{{rev.winner_work_olid}}">
               <img class="bookcover"
                 {# TODO: Fix this once Books have been replaced w/ new model #}
                 {% if revs.works|length > 0 and winner.get('cover_i') %}
@@ -49,7 +49,7 @@
           </div>
           <div class="recommendation--winner--details">
             <h4>
-              <a href="https://openlibrary.org/works/{{rev.winner.work_olid}}">
+              <a href="https://openlibrary.org/works/{{rev.winner_work_olid}}">
                 {{ winner.get('title') }}
               </a>
             </h4>

--- a/bestbook/templates/review.html
+++ b/bestbook/templates/review.html
@@ -2,7 +2,7 @@
 
 <div class="block">
   <div class="recommendation">
-    <div><a href="https://openlibrary.org/works/{{rev.winner_olid}}"><img src="https://covers.openlibrary.org/b/olid/{{rev.winner_olid}}-M.jpg"></a></div>
+    <div><a href="https://openlibrary.org/works/{{rev.winner_work_olid}}"><img src="https://covers.openlibrary.org/b/olid/{{rev.winner_work_olid}}-M.jpg"></a></div>
     <div>
       <p>{{ rev.review }}</p>
       <ul>

--- a/bestbook/templates/user.html
+++ b/bestbook/templates/user.html
@@ -2,7 +2,7 @@
 
 {% for rev in revs %}
   <div>Review: {{rev}}</div>
-  <div>Winner OLID: {{rev.winner}}</div>
+  <div>Winner OLID: {{rev.winner_work_olid}}</div>
   <div>Contender OLIDs: {{rev.contenders}}</div>
   <div>Topic: {{rev.topic}}</div>
 {% endfor %}

--- a/bestbook/views/__init__.py
+++ b/bestbook/views/__init__.py
@@ -185,7 +185,6 @@ class Submit(MethodView):
 
         # candidates will arrive in a different format if POSTed from /admin
         candidates = candidates or ' '.join(request.form.getlist('candidates[]'))
-        print(candidates)
         review = Review.add(
             topic, winner,
             [c for c in candidates.strip().split(' ')],


### PR DESCRIPTION
This solves some issues related to the recent addition of new columns to the `recommendations` table.

1. Submitter and winner OLID are now included whenever a `Review` is created.
2. Removed `submitter` hybrid property, which may have been conflicting with another `Review` property of the same name.
3. In templates, reference the `Review`'s winner OLID and submitter (instead of getting this info from the contenders).

**Note:** Our production `recommendations` table is missing the `submitter` column.  This should probably be added after this PR is merged.