### PR TITLE
Fix user profile 500 error on /users/{username}

### DIFF
--- a/main.py
+++ b/main.py
@@ -602,20 +602,8 @@ def delete_submission(submission_id: int, db: Session = Depends(get_db), user: s
 def _enrich_prompt_details(prompt_list, user_fav_ids=None):
     from collections import Counter
     for p in prompt_list:
-        subs = p.submissions
-        # Sort by score manually since it's a dynamic property
-        subs.sort(key=lambda s: s.score, reverse=True)
-        p.top_books = subs[:10]  # Show top 10 like homepage
-        
-        # Tags for display
-        all_tags = []
-        for s in p.submissions:
-            for t in s.tags:
-                all_tags.append(t.name)
-        
-        tag_counts = Counter(all_tags)
-        # We'll use the property instead
-        pass
+        # Note: p.top_books is already a @property that returns top 10 submissions
+        # No need to set it manually
         
         # Set is_favorited for UI
         p.is_favorited = p.id in user_fav_ids if user_fav_ids else False


### PR DESCRIPTION

Fixes #135 

This PR fixes a 500 Internal Server Error on the User Profile page caused by an `AttributeError` when attempting to set the read-only property `top_books` on the `Prompt` model.

### Changes
- Removed manual assignment `p.top_books = ...` in `_enrich_prompt_details` and let the model's `@property` handle the calculation naturally.
- Removed dead code for tag calculation that was unused.

### Verification
- Verified that `/users/{username}` loads correctly without error.
- Verified that top books still display correctly on user profile cards via the model property.

### Screen recording
https://github.com/user-attachments/assets/4f6f3c76-134c-45b2-86c9-24a6dc1788ce

@mekarpeles Please review it