### PR TITLE
Fix : prompt-meta-row grouping and layout 

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -510,7 +510,7 @@ textarea:focus {
     gap: 10px;
     align-items: center;
     flex-shrink: 0;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 .creator-info span {

--- a/static/style.css
+++ b/static/style.css
@@ -513,7 +513,7 @@ textarea:focus {
     flex-wrap: wrap;
 }
 
-.creator-info span{
+.creator-info span {
     display: flex;
     align-items: center;
     gap: 5px;
@@ -535,13 +535,16 @@ textarea:focus {
     gap: 5px;
     flex-wrap: nowrap; 
     align-items: center;
-    flex:1;
     min-width: 40%;
-    overflow-x: scroll;
+    overflow-x: auto;
     position: relative;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.35) transparent;
 }
 
-
+.prompt-tags-container a{
+    flex-shrink: 0;
+}
 
 .stats-group {
     display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -524,7 +524,7 @@ textarea:focus {
     text-decoration: none;
     font-weight: 500;
     display: inline-block;
-    max-width: 15ch;  /* 15 characters max */
+    max-width: 15ch; 
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -533,7 +533,7 @@ textarea:focus {
 .prompt-tags-container {
     display: flex;
     gap: 5px;
-    flex-wrap: nowrap;  /* Don't wrap - hide with ellipsis instead */
+    flex-wrap: nowrap; 
     align-items: center;
     flex:1;
     min-width: 40%;
@@ -541,20 +541,14 @@ textarea:focus {
     position: relative;
 }
 
-/* .prompt-tags-container::after {
-    content: '...';
-    position: absolute;
-    right: 0;
-    padding-left: 20px;
-    background: linear-gradient(to right, transparent, var(--card-bg) 50%);
-    pointer-events: none;} */
+
 
 .stats-group {
     display: flex;
     gap: 10px;
     flex-shrink: 0;
-    flex-wrap: wrap;  /* Never wrap */
-    white-space: nowrap;  /* Always fit on one line */
+    flex-wrap: wrap;
+    white-space: nowrap;
 }
 
 /* Book Previews */

--- a/static/style.css
+++ b/static/style.css
@@ -497,35 +497,64 @@ textarea:focus {
     font-size: 0.9rem;
     color: #888;
     display: flex;
-    justify-content: space-between;
+    gap: 10px;
     align-items: center;
     border-top: 1px solid #f0f0f0;
     padding-top: 15px;
     margin-top: 10px;
+    flex-wrap: wrap;
 }
 
 .creator-info {
     display: flex;
     gap: 10px;
     align-items: center;
+    flex-shrink: 0;
+    flex-wrap: wrap;
 }
 
-.creator-info img {
-    vertical-align: middle;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
+.creator-info span{
+    display: flex;
+    align-items: center;
+    gap: 5px;
 }
 
 .creator-name {
     color: var(--primary-color);
     text-decoration: none;
     font-weight: 500;
+    display: inline-block;
+    max-width: 15ch;  /* 15 characters max */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
+
+.prompt-tags-container {
+    display: flex;
+    gap: 5px;
+    flex-wrap: nowrap;  /* Don't wrap - hide with ellipsis instead */
+    align-items: center;
+    flex:1;
+    min-width: 40%;
+    overflow-x: scroll;
+    position: relative;
+}
+
+/* .prompt-tags-container::after {
+    content: '...';
+    position: absolute;
+    right: 0;
+    padding-left: 20px;
+    background: linear-gradient(to right, transparent, var(--card-bg) 50%);
+    pointer-events: none;} */
 
 .stats-group {
     display: flex;
-    gap: 15px;
+    gap: 10px;
+    flex-shrink: 0;
+    flex-wrap: wrap;  /* Never wrap */
+    white-space: nowrap;  /* Always fit on one line */
 }
 
 /* Book Previews */

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,14 +60,14 @@
             <div class="creator-info">
                 <img
                     src="https://ui-avatars.com/api/?name={{ prompt.creator_username }}&background=random&size=24&rounded=true">
-                <span>By <a href="/users/{{ prompt.creator_username }}" class="creator-name">{{ prompt.creator_username
-                        }}</a></span>
-                <span class="separator">•</span>
-                <div class="prompt-tags u-margin-b-0 u-display-inline">
-                    {% for tag in prompt.display_tags %}
-                    <a href="/?q={{ tag }}" class="tag">{{ tag }}</a>
-                    {% endfor %}
-                </div>
+                <span>By <a href="/users/{{ prompt.creator_username }}" class="creator-name" title="{{ prompt.creator_username }}">{{ prompt.creator_username }}</a></span>
+            </div>
+            
+            <span class="separator">•</span>
+            <div class="prompt-tags-container">
+                {% for tag in prompt.display_tags %}
+                <a href="/?q={{ tag }}" class="tag">{{ tag }}</a>
+                {% endfor %}
             </div>
 
             <div class="stats-group">


### PR DESCRIPTION
## Description
Fixes #130 - Improved the layout and wrapping behavior of the prompt metadata row.

## Problem
The previous layout had several issues:
- Tags were nested inside `creator-info`, causing them to wrap awkwardly with the username
- Long usernames (>15 chars) didn't truncate with ellipsis
- Stats group could wrap to multiple lines on narrow screens
- Poor flexbox implementation with `justify-content: space-between` didn't handle the three semantic sections properly

## Solution
### HTML Changes (templates/index.html)
- Restructured `.prompt-meta-row` to have three distinct sections:
  1. **Creator info** - Avatar + "By Username"
  2. **Tags container** - Prompt tags (separate from creator info)
  3. **Stats group** - Book/voter/vote/favorite stats
- Moved tags outside of `.creator-info` into new `.prompt-tags-container`
- Added `title` attribute to username link for tooltip on hover

### CSS Changes (static/style.css)
- **Creator name**: Added `max-width: 15ch` to truncate at 15 characters with ellipsis
- **Tags container**: 
  - Set `flex: 1` to take available space
  - Set `flex-wrap: nowrap` with `overflow-x: scroll` for horizontal scrolling when tags overflow
  - Set `min-width: 40%` to prevent excessive shrinking
- **Stats group**: 
  - Set `flex-shrink: 0` to prevent resizing
  - Set `white-space: nowrap` to always keep on one line
  - Adjusted gap from 15px to 10px for better spacing

## Testing
- ✅ Username truncates at 15 characters with ellipsis
- ✅ Hovering username shows full name in tooltip
- ✅ Tags scroll horizontally when they overflow
- ✅ Stats always stay on one line and don't resize
- ✅ Layout works responsively on narrow screens



## Related Issues
Closes #130